### PR TITLE
RF - change regul parameter in classic combat

### DIFF
--- a/clinical_combat/harmonization/QuickCombat.py
+++ b/clinical_combat/harmonization/QuickCombat.py
@@ -23,9 +23,7 @@ class QuickCombat(QuickHarmonizationMethod):
         ignore_handedness_covariate=False,
         use_empirical_bayes=True,
         limit_age_range=False,
-        degree=1,
-        regul_ref=0,
-        regul_mov=0,
+        degree=1
     ):
         """
         use_empirical_bayes: bool
@@ -34,11 +32,6 @@ class QuickCombat(QuickHarmonizationMethod):
             Remove reference data with age outside the range of the moving site.
         degree: int
             Polynomial degree of the age fit.
-        regul_ref: float
-            Regularization parameter for the reference site data.
-        regul_mov: float
-            Regularization parameter for the moving site data.
-
         """
         super().__init__(
             bundle_names,
@@ -49,15 +42,9 @@ class QuickCombat(QuickHarmonizationMethod):
         self.use_empirical_bayes = use_empirical_bayes
         self.limit_age_range = limit_age_range
         self.degree = degree
-        self.regul_ref = regul_ref
-        self.regul_mov = regul_mov
 
         if self.degree < 0:
             raise AssertionError("Degree must be greater than 1.")
-        if self.regul_ref < 0:
-            raise AssertionError("regul_ref must be greater or equal to 0.")
-        if self.regul_mov < 0 and not self.regul_mov == -1:
-            raise AssertionError("regul_mov must be greater or equal to 0, or -1.")
 
 
     def standardize_moving_data(self, X, Y):
@@ -221,8 +208,6 @@ class QuickCombat(QuickHarmonizationMethod):
         self.use_empirical_bayes = self.model_params["use_empirical_bayes"]
         self.limit_age_range = self.model_params["limit_age_range"]
         self.degree = self.model_params["degree"]
-        self.regul_ref = self.model_params["regul_ref"]
-        self.regul_mov = self.model_params["regul_mov"]
 
 
     def set_model_fit_params(self, ref_data, mov_data):
@@ -242,8 +227,6 @@ class QuickCombat(QuickHarmonizationMethod):
         self.model_params["max_age"] = np.max(mov_data["age"])
         self.model_params["nbr_beta_params"] = len(self.get_beta_labels())
         self.model_params["degree"] = self.degree
-        self.model_params["regul_ref"] = self.regul_ref
-        self.model_params["regul_mov"] = self.regul_mov
         
 
     def get_beta_labels(self):

--- a/clinical_combat/harmonization/QuickCombatClinic.py
+++ b/clinical_combat/harmonization/QuickCombatClinic.py
@@ -74,14 +74,18 @@ class QuickCombatClinic(QuickCombat):
             ignore_handedness_covariate,
             use_empirical_bayes=use_empirical_bayes,
             limit_age_range=limit_age_range,
-            degree=degree,
-            regul_ref=regul_ref,
-            regul_mov=regul_mov,
+            degree=degree
         )
+        self.regul_ref = regul_ref
+        if self.regul_ref < 0:
+            raise AssertionError("regul_ref must be greater or equal to 0.")
+        self.regul_mov = regul_mov
+        if self.regul_mov < 0 and not self.regul_mov == -1:
+            raise AssertionError("regul_mov must be greater or equal to 0, or -1.")
         self.nu = nu
-        self.tau = tau
         if self.nu < 0:
             raise AssertionError("nu must be greater or equal to 0.")
+        self.tau = tau
         if self.tau < 1:
             raise AssertionError("tau must be greater or equal to 1.")
 
@@ -104,6 +108,9 @@ class QuickCombatClinic(QuickCombat):
 
         """
         super().initialize_from_model_params(model_filename)
+
+        self.regul_ref = self.model_params["regul_ref"]
+        self.regul_mov = self.model_params["regul_mov"]
         self.nu = self.model_params["nu"]
         self.tau = self.model_params["tau"]
 
@@ -131,6 +138,8 @@ class QuickCombatClinic(QuickCombat):
 
         """
         super().set_model_fit_params(ref_data, mov_data)
+        self.model_params["regul_ref"] = self.regul_ref
+        self.model_params["regul_mov"] = self.regul_mov
         self.model_params["nu"] = self.nu
         self.model_params["tau"] = self.tau
         self.model_params["name"] = "clinic"

--- a/clinical_combat/harmonization/__init__.py
+++ b/clinical_combat/harmonization/__init__.py
@@ -14,6 +14,7 @@ def from_model_name(
     use_empirical_bayes=True,
     limit_age_range=False,
     degree=1,
+    regul=0,
     regul_ref=0,
     regul_mov=0,
     nu=0,
@@ -27,8 +28,7 @@ def from_model_name(
             use_empirical_bayes=use_empirical_bayes,
             limit_age_range=limit_age_range,
             degree=degree,
-            regul_ref=regul_ref,
-            regul_mov=regul_mov
+            regul=regul
         )
     elif name == "clinic":
         QC = QuickCombatClinic(


### PR DESCRIPTION
Change `regul_ref` and `regul_mov` parameters of classic combat to `regul`.  Add the `regul` parameter to the beta  estimation.

Harmonization results are unchanged. @baptisp can you test if this fixes the issue?