### PR TITLE
Make combat accessible to non-root users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:noble-20251001
 
+ENV UV_INSTALL_DIR=/opt/bin
+ENV UV_PYTHON_INSTALL_DIR=/opt/bin
+
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     build-essential \
@@ -17,22 +20,21 @@ ADD https://astral.sh/uv/install.sh /uv-installer.sh
 RUN sh /uv-installer.sh && rm /uv-installer.sh
 
 # Ensure the installed binary is on the `PATH`
-ENV PATH="/root/.local/bin/:$PATH"
+ENV PATH="/opt/bin:$PATH"
 
 # Install python 3.12 via uv
 WORKDIR /
 RUN uv python install 3.12
 
 # Create env
-RUN uv venv --python 3.12 /.venvs/combat
-ENV PATH="/.venvs/combat/bin:$PATH"
+RUN uv venv /opt/venvs/combat --python 3.12
+ENV PATH="/opt/venvs/combat/bin:$PATH"
 RUN uv cache clean
 RUN uv pip install --upgrade pip setuptools==75.1.0 wheel setuptools_scm kiwisolver fonttools
 
 # Install combat
-RUN git clone https://github.com/scil-vital/clinical-ComBAT.git
+ADD https://github.com/scil-vital/clinical-ComBAT.git#1.0.1 /clinical-ComBAT
 WORKDIR /clinical-ComBAT
-RUN git checkout 1.0.1
 RUN uv pip install -e . --no-build-isolation
 
 WORKDIR /


### PR DESCRIPTION
Partially sourced from **scilpy** [container recipe](https://github.com/scilus/containers-scilus/blob/main/containers/scilpy.context/scilpy.Dockerfile).

**This allows non-root users that are part of the `root` group to use `python`, `uv` and above all the `combat` commands.** To do so, I changed all installation locations to be under `/opt`, readable and executable by all in the **root group** (prior, it was installed in the **root** home directory). Still, for the procedure to work, the **`--group-add root` option has to be provided to `docker run`** (similar options also available for singularity/apptainer and other engines), but it's the simpler way to do it that does require creating new non-root users in the container.