### PR TITLE
fix model incoherence and 1 patients issue

### DIFF
--- a/src/clinical_combat/cli/combat_QC.py
+++ b/src/clinical_combat/cli/combat_QC.py
@@ -89,6 +89,7 @@ def main():
         nu=0,
         tau=2,
     )
+    QC.assert_data(mov_data)
     QC.fit(ref_data, ref_data)
 
     metric_name = QC.model_params["metric_name"]
@@ -124,7 +125,7 @@ def main():
 
     print(
         "      Mean Bhattacharrya distance: %f (min: %f, max: %f)"
-        % (np.mean(dists), np.min(dists), np.max(dists))
+        % (np.nanmean(dists), np.nanmin(dists), np.nanmax(dists))
     )
 
     if not args.print_only:

--- a/src/clinical_combat/harmonization/Combat.py
+++ b/src/clinical_combat/harmonization/Combat.py
@@ -153,14 +153,7 @@ class Combat(HarmonizationMethod):
 
         design_ref, y_ref = self.get_design_matrices(ref_data)
 
-        covariate_effect_ref = np.dot(
-            design_ref[bundle_idx][1:, :].transpose(), self.beta[bundle_idx]
-        )
-        ref_dist = y_ref[bundle_idx] - self.alpha[bundle_idx] - covariate_effect_ref
-
-        design_mov, y_mov = self.get_design_matrices(mov_data)
-
-        # Check if reference bundle data length is 1
+        # Check if reference bundle data length is 1 or less
         if len(y_ref[bundle_idx]) <= 1:
             logging.warning(
                 "Cannot calculate Bhattacharyya distance for bundle "
@@ -169,7 +162,14 @@ class Combat(HarmonizationMethod):
             )
             return np.nan
 
-        # Check if moving bundle data length is 1
+        covariate_effect_ref = np.dot(
+            design_ref[bundle_idx][1:, :].transpose(), self.beta[bundle_idx]
+        )
+        ref_dist = y_ref[bundle_idx] - self.alpha[bundle_idx] - covariate_effect_ref
+
+        design_mov, y_mov = self.get_design_matrices(mov_data)
+
+        # Check if moving bundle data length is 1 or less
         if len(y_mov[bundle_idx]) <= 1:
             logging.warning(
                 "Cannot calculate Bhattacharyya distance for bundle "

--- a/src/clinical_combat/harmonization/Combat.py
+++ b/src/clinical_combat/harmonization/Combat.py
@@ -159,6 +159,24 @@ class Combat(HarmonizationMethod):
         ref_dist = y_ref[bundle_idx] - self.alpha[bundle_idx] - covariate_effect_ref
 
         design_mov, y_mov = self.get_design_matrices(mov_data)
+
+        # Check if reference bundle data length is 1
+        if len(y_ref[bundle_idx]) <= 1:
+            logging.warning(
+                "Cannot calculate Bhattacharyya distance for bundle "
+                f"{bundle_name}: insufficient reference data "
+                f"(n={len(y_ref[bundle_idx])}). Returning NaN."
+            )
+            return np.nan
+
+        # Check if moving bundle data length is 1
+        if len(y_mov[bundle_idx]) <= 1:
+            logging.warning(
+                "Cannot calculate Bhattacharyya distance for bundle "
+                f"{bundle_name}: insufficient moving data "
+                f"(n={len(y_mov[bundle_idx])}). Returning NaN."
+            )
+            return np.nan
         covariate_effect_mov = np.dot(
             design_mov[bundle_idx][1:, :].transpose(), self.beta[bundle_idx]
         )


### PR DESCRIPTION
- Handle edge QC case where a model has only one patient by returning NaN, and ignore NaN values when computing summary statistics (mean, min, max)
- Add assertion on moving data before fitting in QC to prevent dimension mismatch